### PR TITLE
Traceroute fixes

### DIFF
--- a/src/traceroute/traceroute.py
+++ b/src/traceroute/traceroute.py
@@ -17,7 +17,7 @@ class Host:
     def from_dict(cls, dictionary):
         return cls(dictionary.get("ip"), dictionary.get("hostname"), dictionary.get("country"), dictionary.get("region"), dictionary.get("city"))
 
-    def __eq__(self, other):
+    def __eq__(self, other):    # pragma: no cover
         if not isinstance(other, type(self)):
             return False
 
@@ -98,7 +98,7 @@ class Traceroute:
         return route
 
 
-def main(arguments, logger):
+def main(arguments, logger):    # pragma: no cover
     try:
         traceroute = Traceroute(arguments.api_token, logger)
         traceroute.fetch_route(arguments.destination, arguments.maximum_number_of_hops, arguments.timeout, arguments.reserved_port)
@@ -106,7 +106,7 @@ def main(arguments, logger):
         logger.info("Quiting...")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     logging.basicConfig(level=logging.INFO, format="[*] %(message)s")
     logger = logging.getLogger()
 

--- a/tests/test_traceroute.py
+++ b/tests/test_traceroute.py
@@ -339,7 +339,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     logger = mocker.Mock()
     mock_validate_api_token = mocker.Mock()
     mocker.patch("traceroute.traceroute.validate_api_token", mock_validate_api_token)
-    mocker.patch("traceroute.traceroute.socket.gethostbyname", mock_gethostbyname)
+    mocker.patch("traceroute.traceroute.gethostbyname", mock_gethostbyname)
 
     mock_traceroute = Traceroute(valid_api_token, logger)
     mock_validate_api_token.assert_called_once_with(valid_api_token)

--- a/tests/test_traceroute.py
+++ b/tests/test_traceroute.py
@@ -368,7 +368,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     expected_ip_call_args = [{"dst": destination_hosts[0]["ip"], "ttl": i} for i in range(1, maximum_number_of_hops + 1)]
     expected_udp_call_args = [{"dport": udp_port}] * maximum_number_of_hops
     mock_sr1.side_effect = mock_route_hostname_given
-    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["ip"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
+    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["target"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
 
     assert len(fetched_route) == index_of_destination
     assert all(actual == expected for actual, expected in zip(map(lambda call: call[1], mock_ip.call_args_list), expected_ip_call_args))
@@ -384,7 +384,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     udp_port = 35697
     expected_ip_call_args = [{"dst": destination_hosts[0]["ip"], "ttl": i} for i in range(1, maximum_number_of_hops + 1)]
     expected_udp_call_args = [{"dport": udp_port}] * maximum_number_of_hops
-    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["ip"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
+    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["target"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
 
     assert len(fetched_route) == maximum_number_of_hops
     assert all(actual == expected for actual, expected in zip(map(lambda call: call[1], mock_ip.call_args_list), expected_ip_call_args))
@@ -400,7 +400,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     udp_port = 35656
     expected_ip_call_args = [{"dst": destination_hosts[0]["ip"], "ttl": i} for i in range(1, index_of_destination + 1)]
     expected_udp_call_args = [{"dport": udp_port}] * index_of_destination
-    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["ip"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
+    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["target"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
 
     assert len(fetched_route) == index_of_destination
     assert all(actual == expected for actual, expected in zip(map(lambda call: call[1], mock_ip.call_args_list), expected_ip_call_args))
@@ -416,7 +416,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     udp_port = 35555
     expected_ip_call_args = [{"dst": destination_hosts[0]["ip"], "ttl": i} for i in range(1, maximum_number_of_hops + 1)]
     expected_udp_call_args = [{"dport": udp_port}] * maximum_number_of_hops
-    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["ip"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
+    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["target"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
 
     assert len(fetched_route) == maximum_number_of_hops
     assert all(actual == expected for actual, expected in zip(map(lambda call: call[1], mock_ip.call_args_list), expected_ip_call_args))
@@ -432,7 +432,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     udp_port = 34456
     expected_ip_call_args = [{"dst": destination_hosts[0]["ip"], "ttl": i} for i in range(1, index_of_destination + 1)]
     expected_udp_call_args = [{"dport": udp_port}] * index_of_destination
-    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["ip"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
+    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["target"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
 
     assert len(fetched_route) == index_of_destination
     assert all(actual == expected for actual, expected in zip(map(lambda call: call[1], mock_ip.call_args_list), expected_ip_call_args))
@@ -450,7 +450,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     mock_ip.reset_mock()
     mock_udp.reset_mock()
     mock_sr1.side_effect = mock_route_ip_given
-    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[1]["ip"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
+    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[1]["target"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
 
     assert len(fetched_route) == maximum_number_of_hops
     assert all(actual == expected for actual, expected in zip(map(lambda call: call[1], mock_ip.call_args_list), expected_ip_call_args))
@@ -471,7 +471,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     udp_port = 33649
     expected_ip_call_args = [{"dst": destination_hosts[0]["ip"], "ttl": i} for i in range(1, maximum_number_of_hops + 1)]
     expected_udp_call_args = [{"dport": udp_port}] * maximum_number_of_hops
-    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["ip"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
+    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[0]["target"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
 
     assert len(fetched_route) == maximum_number_of_hops
     assert all(actual == expected for actual, expected in zip(map(lambda call: call[1], mock_ip.call_args_list), expected_ip_call_args))
@@ -487,7 +487,7 @@ def test_fetch_route(mocker, valid_api_token, destination_hosts, expected_and_mo
     udp_port = 33662
     expected_ip_call_args = [{"dst": destination_hosts[1]["ip"], "ttl": i} for i in range(1, maximum_number_of_hops + 1)]
     expected_udp_call_args = [{"dport": udp_port}] * maximum_number_of_hops
-    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[1]["ip"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
+    fetched_route = mock_traceroute.fetch_route(host=destination_hosts[1]["target"], maximum_number_of_hops=maximum_number_of_hops, udp_port=udp_port)
 
     assert len(fetched_route) == maximum_number_of_hops
     assert all(actual == expected for actual, expected in zip(map(lambda call: call[1], mock_ip.call_args_list), expected_ip_call_args))


### PR DESCRIPTION
It would be unnecessary to test code related to the CLI which makes use of the functionality provided by the `Traceroute` class, which is why I excluded those clauses from being reported by `coverage.py`. I did the same thing for the boilerplate implementation of `__eq__` in class `Host`. After these changes, the branch coverage reported by `coverage.py` is **100%**.

I also fixed a broken patch of `gethostbyname`, which I only noticed thanks to the HTML report generated by `coverage.py` (it's a good idea to measure the coverage of the code you use to test after all). This revealed a bug in my tests, which is that the wrong property was passed to the fetch method of the `Traceroute` class, when passing in destination hosts.